### PR TITLE
Removing unit conversions

### DIFF
--- a/modules/surface/driver/noahmp_output.f90
+++ b/modules/surface/driver/noahmp_output.f90
@@ -120,8 +120,8 @@ contains
      iret = nf90_put_var(ncid, time_id,    itime,                       start=(/itime+1/))
      iret = nf90_put_var(ncid, prcp_id,    water%rain*dt,               start=(/itime+1/))
      iret = nf90_put_var(ncid, qinsur_id,  water%qinsur*1000*dt,        start=(/itime+1/))
-     iret = nf90_put_var(ncid, evap_id,    water%qseva*1000.0*dt,       start=(/itime+1/))
-     iret = nf90_put_var(ncid, tran_id,    sum(water%etrani)*1000.0*dt, start=(/itime+1/))
+     iret = nf90_put_var(ncid, evap_id,    water%qseva*dt,              start=(/itime+1/))
+     iret = nf90_put_var(ncid, tran_id,    sum(water%etrani)*dt,        start=(/itime+1/))
      iret = nf90_put_var(ncid,  smc_id,    water%smc,   start=(/itime+1,1/), count=(/1,nsoil/))
 ! for canopy water
      iret = nf90_put_var(ncid, qintr_id,   water%qintr*dt,             start=(/itime+1/))

--- a/modules/surface/src/WaterModule.f90
+++ b/modules/surface/src/WaterModule.f90
@@ -107,11 +107,10 @@ contains
     ELSE
        water%QINSUR = water%QINSUR+(water%QSNBOT + water%QSDEW) * 0.001
     ENDIF
-    water%QSEVA  = water%QSEVA * 0.001 
 
 ! For vegetation root
    DO IZ = 1, parameters%NROOT
-       water%ETRANI(IZ) = water%ETRAN * water%BTRANI(IZ) * 0.001
+       water%ETRANI(IZ) = water%ETRAN * water%BTRANI(IZ)
     ENDDO
 
 ! #ifdef WRF_HYDRO
@@ -122,7 +121,7 @@ contains
     IF (domain%IST == 2) THEN                                        ! lake
        water%RUNSRF = 0.
        IF(water%WSLAKE >= parameters%WSLMAX) water%RUNSRF = water%QINSUR*1000.             !mm/s
-       water%WSLAKE=water%WSLAKE+(water%QINSUR-water%QSEVA)*1000.*domain%DT -water%RUNSRF*domain%DT   !mm
+       water%WSLAKE = water%WSLAKE + (water%QINSUR *1000.*domain%DT) - (water%QSEVA*domain%DT) - water%RUNSRF*domain%DT   !mm
     ELSE
       ! For soil points
       !---------------------------------------------------------------------

--- a/modules/surface_bmi/driver/noahmp_output.f90
+++ b/modules/surface_bmi/driver/noahmp_output.f90
@@ -120,8 +120,8 @@ contains
      iret = nf90_put_var(ncid, time_id,    itime,                       start=(/itime+1/))
      iret = nf90_put_var(ncid, prcp_id,    water%rain*dt,               start=(/itime+1/))
      iret = nf90_put_var(ncid, qinsur_id,  water%qinsur*1000*dt,        start=(/itime+1/))
-     iret = nf90_put_var(ncid, evap_id,    water%qseva*1000.0*dt,       start=(/itime+1/))
-     iret = nf90_put_var(ncid, tran_id,    sum(water%etrani)*1000.0*dt, start=(/itime+1/))
+     iret = nf90_put_var(ncid, evap_id,    water%qseva*dt,              start=(/itime+1/))
+     iret = nf90_put_var(ncid, tran_id,    sum(water%etrani)*dt,        start=(/itime+1/))
      iret = nf90_put_var(ncid,  smc_id,    water%smc,   start=(/itime+1,1/), count=(/1,nsoil/))
 ! for canopy water
      iret = nf90_put_var(ncid, qintr_id,   water%qintr*dt,             start=(/itime+1/))

--- a/modules/surface_bmi/src/WaterModule.f90
+++ b/modules/surface_bmi/src/WaterModule.f90
@@ -107,11 +107,10 @@ contains
     ELSE
        water%QINSUR = water%QINSUR+(water%QSNBOT + water%QSDEW) * 0.001
     ENDIF
-    water%QSEVA  = water%QSEVA * 0.001 
 
 ! For vegetation root
    DO IZ = 1, parameters%NROOT
-       water%ETRANI(IZ) = water%ETRAN * water%BTRANI(IZ) * 0.001
+       water%ETRANI(IZ) = water%ETRAN * water%BTRANI(IZ)
     ENDDO
 
 ! #ifdef WRF_HYDRO
@@ -122,7 +121,7 @@ contains
     IF (domain%IST == 2) THEN                                        ! lake
        water%RUNSRF = 0.
        IF(water%WSLAKE >= parameters%WSLMAX) water%RUNSRF = water%QINSUR*1000.             !mm/s
-       water%WSLAKE=water%WSLAKE+(water%QINSUR-water%QSEVA)*1000.*domain%DT -water%RUNSRF*domain%DT   !mm
+       water%WSLAKE = water%WSLAKE + (water%QINSUR *1000.*domain%DT) - (water%QSEVA*domain%DT) - water%RUNSRF*domain%DT   !mm
     ELSE
       ! For soil points
       !---------------------------------------------------------------------


### PR DESCRIPTION
ETRAN (transpiration) and QSEVA (evaporation) were previously converted from mm/s to m/s using hard-coded conversions in WaterModule.f90. This is unwanted behavior for the surface module, particularly the BMI implementation.