### PR TITLE
add register_bmi function to enable interoperablity with iso_c_bmif_2_0

### DIFF
--- a/modules/surface_bmi/bmi/Makefile
+++ b/modules/surface_bmi/bmi/Makefile
@@ -5,6 +5,8 @@
 
 include ../user_build_options
 
+F90FLAGS := -cpp ${F90FLAGS}
+
 OBJS = bmi_noahmp.o \
        bmi.o
 

--- a/modules/surface_bmi/bmi/bmi_noahmp.f90
+++ b/modules/surface_bmi/bmi/bmi_noahmp.f90
@@ -1,5 +1,7 @@
 module bminoahmp
 
+! NGEN_ACTIVE is to be set when running in the Nextgen framework
+! https://github.com/NOAA-OWP/ngen
 #ifdef NGEN_ACTIVE
    use bmif_2_0_iso
 #else

--- a/modules/surface_bmi/bmi/bmi_noahmp.f90
+++ b/modules/surface_bmi/bmi/bmi_noahmp.f90
@@ -1038,4 +1038,26 @@ contains
 !     call print_info(this%model)
 !   end subroutine print_model_info
 
+  function register_bmi(this) result(bmi_status) bind(C, name="register_bmi")
+   use, intrinsic:: iso_c_binding, only: c_ptr, c_loc, c_int
+   use iso_c_bmif_2_0
+   implicit none
+   type(c_ptr) :: this ! If not value, then from the C perspective `this` is a void**
+   integer(kind=c_int) :: bmi_status
+   !Create the momdel instance to use
+   !Definitely need to carefully undertand and document the semantics of the save attribute here
+   type(bmi_noahmp), target, save :: bmi_model !need to ensure scope/lifetime, use save attribute
+   !Create a simple pointer wrapper
+   type(box), pointer :: bmi_box
+
+   !allocate the pointer box
+   allocate(bmi_box)
+   !allocate(bmi_box%ptr, source=bmi_model)
+   !associate the wrapper pointer the created model instance
+   bmi_box%ptr => bmi_model
+   !Return the pointer to box
+   this = c_loc(bmi_box)
+   bmi_status = BMI_SUCCESS
+ end function register_bmi
+ 
 end module bminoahmp


### PR DESCRIPTION
This PR will enable the noah-mp bmi module to be useable by the ngen framework via the ISO_C_Binding BMI module (noaa-owp/ngen#282) and the fortran BMI adapter.

This does introduce a dependency on the `iso_c_bmif_2_0` module, which can be found and built in the ngen subproject in `ngen/extern/iso_c_fortran_bmi`.  A PR on the ngen project with this library and the fortran adapter should be up shortly, will update this when it is.