### PR TITLE
Ensure ReadNamelist reads from the passed parameter file

### DIFF
--- a/modules/surface_bmi/src/NamelistRead.f90
+++ b/modules/surface_bmi/src/NamelistRead.f90
@@ -435,7 +435,7 @@ contains
 !---------------------------------------------------------------------
 
     if(structure_option == 1) then       ! user-defined levels
-      open(30, file="namelist.input", form="formatted")
+      open(30, file=config_file, form="formatted")
        read(30, fixed_initial)
       close(30)
     else if(structure_option == 2) then  ! fixed levels


### PR DESCRIPTION
Fixes a bug where the BMI initialization code incorrectly tries to read part of the namelist input from a hardcoded filename `namelist.input` instead of the passed `config_file`.