### PR TITLE
Enable to specify vegetation classification option from namelist

### DIFF
--- a/modules/full/run/namelist.input
+++ b/modules/full/run/namelist.input
@@ -12,6 +12,7 @@
   general_table      = "GENPARM.TBL"                    ! general param tables and misc params
   soil_table         = "SOILPARM.TBL"                   ! soil param table
   noahmp_table       = "MPTABLE.TBL"                    ! noah-mp related param tables
+  veg_class_name     = "MODIFIED_IGBP_MODIS_NOAH"       ! vegetation class data source - "MODIFIED_IGBP_MODIS_NOAH" or "USGS"
 /
 
 &location ! for point runs, needs to be modified for gridded

--- a/modules/full/src/NamelistRead.f90
+++ b/modules/full/src/NamelistRead.f90
@@ -16,6 +16,7 @@ type, public :: namelist_type
   character(len=256) :: noahmp_table       ! name of noahmp parameter table
   character(len=256) :: soil_table         ! name of soil parameter table
   character(len=256) :: general_table      ! name of general parameter table
+  character(len=256) :: veg_class_name     ! name of vegetation classification
   real               :: lat                ! latitude (°)
   real               :: lon                ! longitude (°)
   real               :: preciprate         ! precipitation rate
@@ -87,6 +88,7 @@ contains
     character(len=256) :: output_filename
     character(len=256) :: parameter_dir
     character(len=256) :: soil_table
+    character(len=256) :: veg_class_name
     character(len=256) :: general_table
     character(len=256) :: noahmp_table
     real               :: lat
@@ -139,7 +141,7 @@ contains
     integer       :: evap_srfc_resistance_option
 
     namelist / timing          / dt,maxtime,startdate,enddate,input_filename,output_filename
-    namelist / parameters      / parameter_dir, soil_table, general_table, noahmp_table
+    namelist / parameters      / parameter_dir, general_table, soil_table, noahmp_table, veg_class_name
     namelist / location        / lat,lon
     namelist / forcing         / preciprate,precip_duration,dry_duration,&
                                  precipitating,ZREF
@@ -203,6 +205,7 @@ contains
     this%soil_table         = soil_table
     this%general_table      = general_table
     this%noahmp_table       = noahmp_table
+    this%veg_class_name     = veg_class_name
     this%lat                = lat
     this%lon                = lon
     this%preciprate         = preciprate

--- a/modules/full/src/ParametersType.f90
+++ b/modules/full/src/ParametersType.f90
@@ -202,8 +202,7 @@ contains
     integer                          :: ix
     character(len=50)                :: dataset_identifier
 
-    dataset_identifier = "MODIFIED_IGBP_MODIS_NOAH"   ! This can be in namelist
-    call read_mp_veg_parameters(namelist%parameter_dir, namelist%noahmp_table, dataset_identifier)
+    call read_mp_veg_parameters(namelist%parameter_dir, namelist%noahmp_table, namelist%veg_class_name)
     call read_mp_soil_parameters(namelist%parameter_dir, namelist%soil_table, namelist%general_table)
     call read_mp_rad_parameters(namelist%parameter_dir, namelist%noahmp_table)
     call read_mp_global_parameters(namelist%parameter_dir, namelist%noahmp_table)


### PR DESCRIPTION
There are two options for vegetation classifications now - USGS and MODIFIED_IGBP_MODIS_NOAH 

Now, a user can change the option by specifying in namelist.input.