### PR TITLE
Enable to specify soil classification option from namelist 

### DIFF
--- a/modules/full/run/namelist.input
+++ b/modules/full/run/namelist.input
@@ -12,6 +12,7 @@
   general_table      = "GENPARM.TBL"                    ! general param tables and misc params
   soil_table         = "SOILPARM.TBL"                   ! soil param table
   noahmp_table       = "MPTABLE.TBL"                    ! noah-mp related param tables
+  soil_class_name    = "STAS"                           ! soil class data source - "STAS" or "STAS-RUC"
 /
 
 &location ! for point runs, needs to be modified for gridded

--- a/modules/full/src/NamelistRead.f90
+++ b/modules/full/src/NamelistRead.f90
@@ -16,6 +16,7 @@ type, public :: namelist_type
   character(len=256) :: noahmp_table       ! name of noahmp parameter table
   character(len=256) :: soil_table         ! name of soil parameter table
   character(len=256) :: general_table      ! name of general parameter table
+  character(len=256) :: soil_class_name    ! name of soil classification
   real               :: lat                ! latitude (°)
   real               :: lon                ! longitude (°)
   real               :: preciprate         ! precipitation rate
@@ -89,6 +90,7 @@ contains
     character(len=256) :: soil_table
     character(len=256) :: general_table
     character(len=256) :: noahmp_table
+    character(len=256) :: soil_class_name
     real               :: lat
     real               :: lon
     real               :: preciprate
@@ -139,7 +141,7 @@ contains
     integer       :: evap_srfc_resistance_option
 
     namelist / timing          / dt,maxtime,startdate,enddate,input_filename,output_filename
-    namelist / parameters      / parameter_dir, soil_table, general_table, noahmp_table
+    namelist / parameters      / parameter_dir, soil_table, general_table, noahmp_table, soil_class_name
     namelist / location        / lat,lon
     namelist / forcing         / preciprate,precip_duration,dry_duration,&
                                  precipitating,ZREF
@@ -203,6 +205,7 @@ contains
     this%soil_table         = soil_table
     this%general_table      = general_table
     this%noahmp_table       = noahmp_table
+    this%soil_class_name    = soil_class_name
     this%lat                = lat
     this%lon                = lon
     this%preciprate         = preciprate

--- a/modules/full/src/ParametersRead.f90
+++ b/modules/full/src/ParametersRead.f90
@@ -569,14 +569,16 @@ CONTAINS
 
   END SUBROUTINE read_mp_veg_parameters
 
-  SUBROUTINE read_mp_soil_parameters(param_dir, soil_table, general_table)
+  SUBROUTINE read_mp_soil_parameters(param_dir, soil_table, general_table, soil_class_name)
     implicit none
     character(len=*), intent(in) :: param_dir
     character(len=*), intent(in) :: soil_table
     character(len=*), intent(in) :: general_table
+    character(len=*), intent(in) :: soil_class_name
     integer             :: IERR
-    character*4         :: SLTYPE
+    character(len=20)   :: SLTYPE
     integer             :: ITMP, NUM_SLOPE, LC
+    integer             :: iLine               ! loop index
     character(len=256)  :: message
     logical             :: file_named
 
@@ -622,11 +624,15 @@ CONTAINS
       call handle_err(ierr, message)
     end if
 
-    READ (21,*)
-    READ (21,*) SLTYPE
+    do iLine = 1,100
+      READ (21,*) SLTYPE
+      if (trim(SLTYPE) == trim(soil_class_name)) exit
+    end do
+
     READ (21,*) SLCATS
-    WRITE( message , * ) 'SOIL TEXTURE CLASSIFICATION = ', TRIM ( SLTYPE ) , ' FOUND', &
-               SLCATS,' CATEGORIES'
+
+    WRITE( message , * ) 'SOIL TEXTURE CLASSIFICATION = ', TRIM ( SLTYPE ) , ' FOUND', SLCATS,' CATEGORIES'
+    print*, message
     !CALL wrf_message ( message )
 
     DO LC=1,SLCATS

--- a/modules/full/src/ParametersType.f90
+++ b/modules/full/src/ParametersType.f90
@@ -204,7 +204,7 @@ contains
 
     dataset_identifier = "MODIFIED_IGBP_MODIS_NOAH"   ! This can be in namelist
     call read_mp_veg_parameters(namelist%parameter_dir, namelist%noahmp_table, dataset_identifier)
-    call read_mp_soil_parameters(namelist%parameter_dir, namelist%soil_table, namelist%general_table)
+    call read_mp_soil_parameters(namelist%parameter_dir, namelist%soil_table, namelist%general_table, namelist%soil_class_name)
     call read_mp_rad_parameters(namelist%parameter_dir, namelist%noahmp_table)
     call read_mp_global_parameters(namelist%parameter_dir, namelist%noahmp_table)
 


### PR DESCRIPTION
There are two soil class options for soil parameter lookup now - STAS and STAS-RUC

Now, a user can select the option by specifying in namelist.input.