### PR TITLE
Fix integer division rounding to 0

### DIFF
--- a/src/SurfaceRunoffInfiltration.f90
+++ b/src/SurfaceRunoffInfiltration.f90
@@ -682,10 +682,10 @@ contains
      ! Sorptivity approximations. Transport in Porous Media 1.1, 57-62.
      SP = SQRT(2 * (parameters%SMCMAX(ISOIL) - parameters%SMCWLT(ISOIL)) * (parameters%DWSAT(ISOIL) - WDF))
      ! Parameter A in Eq. 9 of Valiantzas (2010) is given by
-     AP = MIN(WCND, (2/3)*parameters%DKSAT(ISOIL))
-     AP = MAX(AP,   (1/3)*parameters%DKSAT(ISOIL))
+     AP = MIN(WCND, (2.0/3)*parameters%DKSAT(ISOIL))
+     AP = MAX(AP,   (1.0/3)*parameters%DKSAT(ISOIL))
      ! Maximun infiltration rate, m
-     FSUR = (1/2)*SP*(DT**(-1/2))+AP ! m/s
+     FSUR = (1.0/2)*SP*(DT**(-1.0/2))+AP ! m/s
      IF(FSUR .LT. 0.0) FSUR = 0.0
    ELSE
      ! estimate initial soil hydraulic conductivty and diffusivity (Ki, D(theta) in the equation)
@@ -694,10 +694,10 @@ contains
      ! Sorptivity approximations. Transport in Porous Media 1.1, 57-62.
      SP = SQRT(2 * (parameters%SMCMAX(ISOIL) - water%SMC(ISOIL)) * (parameters%DWSAT(ISOIL) - WDF))
      ! Parameter A in Eq. 9 of Valiantzas (2010) is given by
-     AP = MIN(WCND, (2/3)*parameters%DKSAT(ISOIL))
-     AP = MAX(AP,   (1/3)*parameters%DKSAT(ISOIL))
+     AP = MIN(WCND, (2.0/3)*parameters%DKSAT(ISOIL))
+     AP = MAX(AP,   (1.0/3)*parameters%DKSAT(ISOIL))
      ! Maximun infiltration rate, m
-     FSUR = (1/2)*SP*(DT**(-1/2))+AP ! m/s
+     FSUR = (1.0/2)*SP*(DT**(-1.0/2))+AP ! m/s
      ! infiltration rate at surface
      IF(parameters%DKSAT(ISOIL) .LT. water%QINSUR)THEN
        FSUR = MIN(water%QINSUR,FSUR)


### PR DESCRIPTION
Based on warnings from gfortran 14:

```
gfortran-14 -c -cpp -g -fbacktrace -Wall -fcheck=all  -ffree-form  -ffree-line-length-none  -I../driver SurfaceRunoffInfiltration.f90
SurfaceRunoffInfiltration.f90:685:22:

  685 |      AP = MIN(WCND, (2/3)*parameters%DKSAT(ISOIL))
      |                      1
Warning: Integer division truncated to constant '0' at (1) [-Winteger-division]
SurfaceRunoffInfiltration.f90:686:22:

  686 |      AP = MAX(AP,   (1/3)*parameters%DKSAT(ISOIL))
      |                      1
Warning: Integer division truncated to constant '0' at (1) [-Winteger-division]
SurfaceRunoffInfiltration.f90:688:29:

  688 |      FSUR = (1/2)*SP*(DT**(-1/2))+AP ! m/s
      |                             1
Warning: Integer division truncated to constant '0' at (1) [-Winteger-division]
SurfaceRunoffInfiltration.f90:697:22:

  697 |      AP = MIN(WCND, (2/3)*parameters%DKSAT(ISOIL))
      |                      1
Warning: Integer division truncated to constant '0' at (1) [-Winteger-division]
SurfaceRunoffInfiltration.f90:698:22:

  698 |      AP = MAX(AP,   (1/3)*parameters%DKSAT(ISOIL))
      |                      1
Warning: Integer division truncated to constant '0' at (1) [-Winteger-division]
SurfaceRunoffInfiltration.f90:700:29:

  700 |      FSUR = (1/2)*SP*(DT**(-1/2))+AP ! m/s
      |                             1
Warning: Integer division truncated to constant '0' at (1) [-Winteger-division]
```