### PR TITLE
Add OPT_BTR=4 and OPT_RSF=5 to approximate PET by maximizing transpiration and evaporation

### DIFF
--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: noaa-owp/ngen
 
-	  - name: Install uv
+      - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"

--- a/.github/workflows/ngen_integration.yaml
+++ b/.github/workflows/ngen_integration.yaml
@@ -85,7 +85,7 @@ jobs:
         id: submod_build_6
         uses: ./.github/actions/ngen-submod-build
         with:
-		  cmake-flags: -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          cmake-flags: -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           mod-dir: "extern/sloth/"
           targets: "slothmodel"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,9 @@
 # Changelog for Noah-OWP-Modular 
 
 ## Major changes:
+- Add options to approximate PET by maximizing transpiration and soil evaporation (output name is still EVAPOTRANS)
+    - Added `stomatal_resistance_option = 4` (OPT_BTR=4): Minimizes RS, and removes soil moisture stress (BTRAN=1.0) to maximize transpiration for a PET like output
+    - Added `evap_srfc_resistance_option = 5` (OPT_RSF=5): Sets RSURF=0.001 when FSNO=0 for maximum soil evaporation, and applies weighted mean (RSURF_SNOW for snow fraction, 0.001 for bare soil) when snow is present
 - Removed PGS from PHENOLOGY because we’re not implementing CARBON_CROP
 - Moved CanopyWaterIntercept to InterceptionModule
     - Removed call from WaterModule and added to InterceptionModule

--- a/src/EnergyModule.f90
+++ b/src/EnergyModule.f90
@@ -167,6 +167,9 @@ contains
           END IF
           GX = 1.-EXP(-5.8*(LOG(parameters%PSIWLT/PSI)))
         END IF
+        IF(options%OPT_BTR == 4) then                  ! Maximum ETRAN (no soil moisture stress)
+          GX = 1.0
+        END IF
         GX = MIN(1.,MAX(0.,GX))
         water%BTRANI(IZ) = MAX(parameters%MPE, domain%DZSNSO(IZ) / (-domain%ZSOIL(parameters%NROOT)) * GX)
         water%BTRAN      = water%BTRAN + water%BTRANI(IZ)
@@ -181,7 +184,7 @@ contains
       energy%RSURF = 1.0         ! avoid being divided by 0
       energy%RHSUR = 1.0
     ELSE
-      IF(options%OPT_RSF == 1 .OR. options%OPT_RSF == 4) THEN
+      IF(options%OPT_RSF == 1 .OR. options%OPT_RSF == 4 .OR. options%OPT_RSF == 5) THEN
         ! RSURF based on Sakaguchi and Zeng, 2009
         ! taking the "residual water content" to be the wilting point,
         ! and correcting the exponent on the D term (typo in SZ09 ?)
@@ -196,6 +199,10 @@ contains
     ENDIF
     IF(options%OPT_RSF == 4) THEN                                     ! AD: FSNO weighted; snow RSURF set in MPTABLE v3.8
       energy%RSURF = 1. / (water%FSNO * (1./parameters%RSURF_SNOW) + (1.-water%FSNO) * (1./max(energy%RSURF, 0.001)))
+    ENDIF
+    IF(options%OPT_RSF == 5) THEN                                     ! Minimize RSURF for soil evap; preserve sublimation when snow present
+      ! Weighted mean: RSURF_SNOW for snow fraction, 0.001 for non-snow fraction
+      energy%RSURF = 1. / (water%FSNO * (1./parameters%RSURF_SNOW) + (1.-water%FSNO) * (1./0.001))
     ENDIF
     IF(water%SH2O(1) < 0.01 .and. water%SNOWH == 0.) energy%RSURF = 1.E6
       PSI   = -parameters%PSISAT(1) * (MAX(0.01, water%SH2O(1))/parameters%SMCMAX(1))**(-parameters%BEXP(1))

--- a/src/EtFluxModule.f90
+++ b/src/EtFluxModule.f90
@@ -301,6 +301,12 @@ contains
                         energy%RSSHA, energy%PSNSHA )                                       ! out                   
         END IF
         
+        ! Maximum ETRAN: Force minimum stomatal resistance when OPT_BTR=4
+        IF (options%OPT_BTR == 4) THEN
+          energy%RSSUN = parameters%RSMIN
+          energy%RSSHA = parameters%RSMIN
+        END IF
+        
         ! Call GECROS
         ! Note:  GECROS option (opt_crop == 2) is not currently supported. 
        

--- a/src/NamelistRead.f90
+++ b/src/NamelistRead.f90
@@ -266,8 +266,8 @@ contains
     if (.not. is_within_bound(snowsoil_temp_time_option, 1, 3)) then; call sys_abort(1,'model options: snowsoil_temp_time_option should be 1-3'); end if
     if (.not. is_within_bound(soil_temp_boundary_option, 1, 2)) then; call sys_abort(1,'model options: soil_temp_boundary_option should be 1-2'); end if
     if (.not. is_within_bound(supercooled_water_option, 1, 2)) then; call sys_abort(1,'model options: supercooled_water_option should be 1-2'); end if
-    if (.not. is_within_bound(stomatal_resistance_option, 1, 3)) then; call sys_abort(1,'model options: stomatal_resistance_option should be 1-3'); end if
-    if (.not. is_within_bound(evap_srfc_resistance_option, 1, 4)) then; call sys_abort(1,'model options: evap_srfc_resistance_option should be 1-4'); end if
+    if (.not. is_within_bound(stomatal_resistance_option, 1, 4)) then; call sys_abort(1,'model options: stomatal_resistance_option should be 1-4'); end if
+    if (.not. is_within_bound(evap_srfc_resistance_option, 1, 5)) then; call sys_abort(1,'model options: evap_srfc_resistance_option should be 1-5'); end if
     if (.not. is_within_bound(subsurface_option, 1, 3)) then; call sys_abort(1,'model options: subsurface_option should be 1-3'); end if
 
     !  after reading # of soil layers, allocate local arrays and read soil structure info

--- a/src/OptionsType.f90
+++ b/src/OptionsType.f90
@@ -94,12 +94,14 @@ type, public :: options_type
                         !   1 -> Noah (soil moisture) 
                         !   2 -> CLM  (matric potential)
                         !   3 -> SSiB (matric potential)
+                        !   4 -> Maximum ETRAN (BTRAN=1.0, RS=RSMIN) to approximate PET
   integer :: opt_rsf    ! evap_srfc_resistance_option
                         ! options for surface resistance to evaporation/sublimation
                         !   1 -> Sakaguchi and Zeng, 2009
                         !   2 -> Sellers (1992)
                         !   3 -> adjusted Sellers to decrease RSURF for wet soil
                         !   4 -> option 1 for non-snow; rsurf = rsurf_snow for snow (set in MPTABLE); AD v3.8
+                        !   5 -> minimize RSURF for soil evap; weight by FSNO when FSNO > 0 (approximate PET)
   integer :: opt_sub    ! subsurface_option
                         ! options for subsurface realization
                         !   1 -> full Noah-MP style subsurface


### PR DESCRIPTION
New options in `OptionsType.f90` to maximize transpiration and evaporation as an approximation of PET:

OPT_BTR=4: Maximize transpiration by reducing stomatal resistance
- Sets BTRAN=1 (no soil moisture stress)
- Sets RS=RSMIN (minimum stomatal resistance)

OPT_RSF=5: Maximize soil evaporation by reducing resistance
- Minimizes RSURF to maximize soil evaporation
- Weights RSURF and RSURF_SNOW by snow cover fraction to avoid increasing sublimation of the snowpack

Output variables still have the same names.